### PR TITLE
simplify event listener attachments

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -188,7 +188,7 @@ html{
   display: inline-block;
 }
 
-.chatbox_bttn {
+#chatbox_bttn {
   position: relative;
   bottom: -33em;
   right: -18rem;
@@ -200,7 +200,7 @@ html{
   filter: drop-shadow(0 0 2rem black);
 }
 
-.chatbox_bttn img {
+#chatbox_bttn img {
   position: relative;
   margin: auto;
   padding: 0.5em;

--- a/public/index.html
+++ b/public/index.html
@@ -17,12 +17,12 @@
         <img src="img/background.png" alt="" class="background">
     </div>
 
-    <button class="chatbox_bttn">
+    <button id="chatbox_bttn">
         <img src="img/OntarioTechUniversity_Symbol_Colour_RGB_300ppi.png" class="chatbox_logo">
     </button>
 
     <div id="chat-column-holder" class="responsive-column content-column">
-      <div class="chat-column">
+      <div id="chat-column" class="chat-column">
         <div id="scrollingChat"></div>
         <p class="user-typing" id="user-typing-field"></p>
         <label for="textInput" class="inputOutline">

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1,56 +1,35 @@
 
-let chat_bttn = document.getElementsByClassName("chatbox_bttn")
-let chat_cntnr = document.getElementsByClassName("chat-column")
+let chat_bttn = document.getElementById("chatbox_bttn")
+let chat_cntnr = document.getElementById("chat-column")
 let innerMessage = document.getElementsByClassName("message-inner")
 let options_list = document.getElementsByClassName("options-list")
 let scrolling_chat = document.getElementById("scrollingChat")
 let para = document.getElementsByTagName('p')
 
 window.onload = function(){
-
+  if (chat_bttn) {
   // this is used to open and close chat box
-  Array.from(chat_bttn).forEach(function(element) {
-    element.addEventListener('click', function (){ 
-      // console.log("works");
-
-      // get the chat conationer
-      Array.from(chat_cntnr).forEach(function(e){
-        // check what displaytype the container is using
-        if(e.style.display == 'flex'){
-          // console.log("true")
-          // disable the container
-          e.style.display = 'none'
-        }else{
-          // enable the container
-          e.style.display = 'flex'
-          // console.log("false")
-        }
-
-        if(e.contains(scrolling_chat)){
-
-          Array.from(options_list).forEach(function(element){
-            element.addEventListener('click', updater)
-              // clearTimeout(updater)
-            })
-          // })
-        }else{
-          console.log("chat box doesnt exist")
-        }
-
-      });// end of chat container lop
-
-    });// end of  button listener
-
-  });// end of button class loop
-
+    chat_bttn.addEventListener('click', function (){
+      if(chat_cntnr.style.display === 'flex'){
+        // console.log("true")
+        // disable the container
+        chat_cntnr.style.display = 'none'
+      }else{
+        // enable the container
+        chat_cntnr.style.display = 'flex'
+        // console.log("false")
+      }
+      [...options_list].forEach(element => element.addEventListener('click', updater));
+    });
+  }
 }// end of window onload
 
 function updater(){
   let chatNodes = scrolling_chat.childNodes;
 
   // setTimeout(() => {
-    console.log(chatNodes.length)
-    Array.from(chatNodes).forEach(function(element){
+    console.log(chatNodes.length);
+    [...chatNodes].forEach(function(element){
       let newChatNodes = element.childNodes
       console.log(newChatNodes); 
     })


### PR DESCRIPTION
- changed a couple of classes back to ids since they can be _single_ elements that _are_ accessed from JS (such as `chat_bttn`)
- since `chat_bttn` will only ever be on the page once, we get it by its id and check for that one button's existence
- removed loops since singular elements can be accessed directly
- `options_list` is what we really want, don't need refs to `scrolling_chat`
- `chat_cntr` can be referenced directly for styles